### PR TITLE
fix: corrigido suporte ao encoding ISO-8859-8 no método RemoveDiacritics

### DIFF
--- a/src/Toletus.Pack.Core/Extensions/StringExtensions.cs
+++ b/src/Toletus.Pack.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Toletus.Pack.Core.Extensions
 {
@@ -24,8 +25,9 @@ namespace Toletus.Pack.Core.Extensions
 
         public static string RemoveDiacritics(this string input)
         {
-            var tempBytes = System.Text.Encoding.GetEncoding("ISO-8859-8").GetBytes(input);
-            var asciiStr = System.Text.Encoding.UTF8.GetString(tempBytes);
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            var tempBytes = Encoding.GetEncoding("ISO-8859-8").GetBytes(input);
+            var asciiStr = Encoding.UTF8.GetString(tempBytes);
 
             return asciiStr;
         }


### PR DESCRIPTION
Adicionado o registro do CodePagesEncodingProvider para habilitar o suporte ao encoding ISO-8859-8, resolvendo o erro "ISO-8859-8 is not a supported encoding name".

Alterações:
- Método `RemoveDiacritics` atualizado para registrar o provedor de encodings adicionais.